### PR TITLE
Don't explicitly add LESS paths for symlinked PHP packages

### DIFF
--- a/src/getPhpWatchPaths.ts
+++ b/src/getPhpWatchPaths.ts
@@ -76,11 +76,11 @@ export async function getPhpIgnorePaths() {
  */
 export async function getPhpWatchPaths() {
   const symlinkPaths = await getPhpSymlinkPaths();
+  // Note: We don't want to include LESS files within the PHP package as they
+  // should already be wymlinked under the project's www directory and will
+  // be watched using the default paths.less paths.
   const symlinkFilePaths = symlinkPaths
-    .map((symlinkPath) => [
-      `${symlinkPath}/**/*.php`,
-      `${symlinkPath}/**/*.less`,
-    ])
+    .map((symlinkPath) => [`${symlinkPath}/**/*.php`])
     .flat();
 
   const wwwPaths = await getWwwPaths(


### PR DESCRIPTION
Adding these paths explicitly will cause them to be watched twice:

 1. Once as an absolute path
 2. Once as a symlink under the project www/packages folder

We only should watch the file in the second case. Watching in the first case will cause LESS compilation errors because the file path will be absolute intead of relative.